### PR TITLE
Split User into User and UserRef (no password)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-models",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Shared models and validation for the Bicycle Touring Companion",
   "scripts": {
     "prepublish": "npm run build",

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ export { serviceTypes, alertTypes, display } from './model/point';
 
 export { Schedule, days, nextDay, timezones } from './model/hours';
 
-export { User, UserCollection, Login } from './model/user';
+export { User, UserCollection, UserRef, UserRefCollection, Login } from './model/user';
 export { Point, Service, Alert, PointCollection, Comment, CommentCollection } from './model/point';
 
 import { Point, Service, Alert, PointCollection, Comment, CommentCollection } from './model/point';


### PR DESCRIPTION
This PR splits the User model into the User and UserRef models. CouchDB does not return passwords with user docs. Therefore, when we wanted to modify Users after initial creation, validation failed (as passwords were required). The UserRef model does not include the password field in its validation.

This PR also maintains the change with UserCollection and UserRefCollection.

Also, bump semver to 0.4.2.
